### PR TITLE
docker opts tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,17 @@ your distribution). You have to restart the docker service to take the changes
 into account. Sometimes the interface is not updated, you will have to restart
 your host.
 
+    # For systemd users (Fedora and recent Ubuntu versions) :
+    $ vim /lib/systemd/system/docker.service
+    # append the --bip="172.17.42.1/24" option to the ExecStart line
+    # then
+    $ sudo systemctl daemon-reload
+
+    # For other users
     $ vim /etc/default/docker
     DOCKER_OPTS="--bip=172.17.42.1/24"
 
+    # In any cases
     $ sudo service docker restart
 
 **One more thing** When you start your host, the docker service is not fully
@@ -99,9 +107,17 @@ changes its DNS (ie: network switching) by using the container [dns-sync].
 When coupled with dns-sync, you can force all containers to use this DNS by
 updating the docker's default options
 
+    # For systemd users (Fedora and recent Ubuntu versions) :
+    $ vim /lib/systemd/system/docker.service
+    # append the --bip="172.17.42.1/24" --dns="172.17.42.1" options to the ExecStart line
+    # then
+    $ sudo systemctl daemon-reload
+
+    # For other users
     $ vim /etc/default/docker
     DOCKER_OPTS="--bip=172.17.42.1/24 --dns=172.17.42.1"
 
+    # In any cases
     $ sudo service docker restart
 
   [docker-gen]: https://github.com/jwilder/docker-gen


### PR DESCRIPTION
Hi,

First of all thanks for sharing this and your slides of sfLive2015 :+1: 
I tried to setup this dev env on my machine but I had some troubles with the docker0 interface changing its IP address at every startup.
Finally, I figured it out by following [this instruction](https://github.com/tonistiigi/dnsdock#setup).
That's why I propose to include the solution into your readme file.

By the way, I had performance troubles even with activating the docker service this way :

``` bash
sudo update-rc.d docker enable
```

but replacing the `enable` instruction with `defaults` looks to have solved my problem.
I can make a PR for this too if you wish.

For info, I'm running on Ubuntu Gnome 15.04, linux 4.2.0, docker 1.8.3, docker-compose 1.4.2 .
