### PR TITLE
Use the --no-cache option with apk ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER Jérémy Derussé "jeremy@derusse.com"
 
-RUN apk -U add \
+RUN apk --no-cache add \
     dnsmasq \
     openssl
 


### PR DESCRIPTION
...to prevent the index being stored in the resulting image.

This reduces the image size from 16.33MB to 15.57MB.
