### PR TITLE
Fix initialisation when container start after reboot

### DIFF
--- a/docker-files/usr/local/bin/entrypoint
+++ b/docker-files/usr/local/bin/entrypoint
@@ -4,6 +4,8 @@ echo "Ignoring server ${GATEWAY}"
 
 docker-gen -watch -only-exposed -notify "dnsmasq-reload -u root $*" /etc/dnsmasq.tmpl /etc/dnsmasq.conf &
 
+dnsmasq-reload -u root $*
+
 while true; do
     sed "/${GATEWAY}/d" "/host$(chroot /host realpath -L /etc/resolv.conf)" > /etc/resolv.dnsmasq
     sleep 1


### PR DESCRIPTION
Hi,

Firstly, thanks for this great tool.

Issue
-----

After reboot, DNS server is unavailable.

Solution found
----------

Force execution of `dnsmasq-reload` when container start.

Tests
-----

Start your computer, then execute the following command.

```
docker run --rm heywoodlh/dnsutils dig github.com
```

You should see the IP address of the docker0 interface. `172.17.0.1` on this example.

```
;; ANSWER SECTION:
github.com.		60	IN	A	140.82.121.4

;; SERVER: 172.17.0.1#53(172.17.0.1)
```