### PR TITLE
Fix restarting dnsmasq after kill it

### DIFF
--- a/docker-files/usr/local/bin/dnsmasq-reload
+++ b/docker-files/usr/local/bin/dnsmasq-reload
@@ -1,4 +1,9 @@
 #!/usr/bin/env sh
 
 killall dnsmasq
+
+# Give enough time to terminate the process.
+#
+sleep 1
+
 /usr/sbin/dnsmasq "$@"


### PR DESCRIPTION
This provides a patch for #29

Issue
-----

On container log you can see this error.

```
Error running notify command: dnsmasq-reload -u root , exit status 2
```

The error from `dnsmasq` output.

```
dnsmasq: failed to create listening socket for 172.17.0.1: Address in use
```

Solution found
----------

Wait after kill all `dnsmasq` processes.


Tests
-----

Execute the following command inside the container.
Platform: Ubuntu 20.04.5

```
dnsmasq-reload -u root
```